### PR TITLE
PID and VID for tp link ax1750u

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -155,6 +155,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/*=== ASUS USB-AX55 =======*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_ASUS, 0x1a62, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 
+	/*=== TPLINK 1750U Nano =======*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x0108, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 #endif /* CONFIG_RTL8852B */
 #ifdef CONFIG_RTL8852BP

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -140,7 +140,7 @@ static void rtw_dev_shutdown(struct device *dev)
 #define USB_VENDOR_ID_ASUS  		0x0B05
 #define USB_VENDOR_ID_BUFFALO		0x0411
 #define USB_VENDOR_ID_DLINK 		0x2001
-#define USB_VENDOR_ID_TPLINK 		0x2357
+#define USB_VENDOR_ID_TPLINK 		0x35bc
 
 /* DID_USB_v916_20130116 */
 static struct usb_device_id rtw_usb_id_tbl[] = {
@@ -154,6 +154,8 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 
 	/*=== ASUS USB-AX55 =======*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_ASUS, 0x1a62, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
+
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x0108, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 #endif /* CONFIG_RTL8852B */
 #ifdef CONFIG_RTL8852BP
 	/*=== Realtek demoboard ===*/


### PR DESCRIPTION
I have a [tp link Archer TX1750U nano](https://www.tp-link.com/us/home-networking/usb-adapter/archer-tx1750u-nano/). I added the PID and VID for this adapter. The LED functionality is obviously missing but I am able to connect to networks.